### PR TITLE
WIP - Dockerize backend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get install wget gnupg2 apt-utils -y
+
+RUN wget -qO- http://packages.swarmops.com/swarmops-packages.gpg.key | apt-key add -
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+RUN echo deb http://packages.swarmops.com/ bionic contrib > /etc/apt/sources.list.d/swarmops.list
+RUN echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic main" > /etc/apt/sources.list.d/mono-official-stable.list
+RUN apt-get update
+
+RUN apt-get install swarmops-backend -y
+
+RUN echo "Yo"
+
+CMD [ "/bin/bash" ]


### PR DESCRIPTION
Very naive attempt to "dockerize" Swarmops backend.

Things bugging me ATM:

- [ ] apt-key being parsed (nb clue what that is / means)
  ```
   Step 3/10 : RUN wget -qO- http://packages.swarmops.com/swarmops-packages.gpg.key | apt-key add -
    ---> Running in ce827bc52bbd
   Warning: apt-key output should not be parsed (stdout is not a terminal)
   OK
   Removing intermediate container ce827bc52bbd
    ---> a796f7555902
   Step 4/10 : RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
    ---> Running in 9490866bf683
   Warning: apt-key output should not be parsed (stdout is not a terminal)
   Executing: /tmp/apt-key-gpghome.5rj3PABXHk/gpg.1.sh --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
   gpg: key A6A19B38D3D831EF: 2 signatures not checked due to missing keys
   gpg: key A6A19B38D3D831EF: public key "Xamarin Public Jenkins (auto-signing) <releng@xamarin.com>" imported
   gpg: Total number processed: 1
   gpg:               imported: 1
   Removing intermediate container 9490866bf683
    ---> b317931286b5
   ```
- [ ] `apt-get install swarmops-backend -y` failing (probably because of the above)